### PR TITLE
Update quickstart template to support baseurl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,56 @@
-_python/*.pyc
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/

--- a/_layouts/_base.html
+++ b/_layouts/_base.html
@@ -15,8 +15,13 @@
     {%   set theme_path = "bootstrap/" + bootstrap + "/css" %}
     {% endif %}
     <link href="//netdna.bootstrapcdn.com/{{theme_path}}/bootstrap.min.css" rel="stylesheet" media="screen">
-    <link href="/css/site.css" rel="stylesheet" media="screen">
-    <link href="/css/syntax.css" rel="stylesheet" media="screen">
+
+    {% set url_prefix = '' %}
+    {% if site.baseurl %}
+    {%   set url_prefix = '/' + site.baseurl %}
+    {% endif %}
+    <link href="{{url_prefix + '/css/site.css'}}" rel="stylesheet" media="screen">
+    <link href="{{url_prefix + '/css/syntax.css'}}" rel="stylesheet" media="screen">
 
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
@@ -46,12 +51,12 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a class="navbar-brand" href="/">{{site.brand}}</a>
+          <a class="navbar-brand" href="{{url_prefix + '/'}}">{{site.brand}}</a>
         </div>
         <div class="navbar-collapse collapse">
 
           <ul class="nav navbar-nav navbar-left">
-            {% block home %} 
+            {% block home %}
             {% endblock %}
             {% for item in site.reflinks['/'].content[:-navbar_right_items] %}
             {%   set context = '' %}
@@ -63,7 +68,7 @@
               <a href="{{item.url}}" class="dropdown-toggle" data-toggle="dropdown">{{item.title}} <b class="caret"></b></a>
               <ul class="dropdown-menu">
                 {% for subitem in item.content %}
-                <li><a href="{{subitem.url}}">{{subitem.title}}</a></li>    
+                <li><a href="{{subitem.url}}">{{subitem.title}}</a></li>
                 {% endfor %}
               </ul>
             </li>
@@ -84,7 +89,7 @@
               <a href="{{item.url}}" class="dropdown-toggle" data-toggle="dropdown">{{item.title}} <b class="caret"></b></a>
               <ul class="dropdown-menu">
                 {% for subitem in item.content %}
-                <li><a href="{{subitem.url}}">{{subitem.title}}</a></li>    
+                <li><a href="{{subitem.url}}">{{subitem.title}}</a></li>
                 {% endfor %}
               </ul>
             </li>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -6,7 +6,7 @@
 
   {% block breadcrumbs %}
   <ol class="breadcrumb">
-    <li><a href="/">Home</a></li>
+    <li><a href="{{url_prefix + '/'}}">Home</a></li>
       {% for bc in this.breadcrumbs[:-1] %}
       <li><a href="{{bc.url}}">{{bc.title}}</a></li>
       {% endfor %}
@@ -15,7 +15,7 @@
   {% endblock %}
 
   <div class="page-header">
-    {% block title %} 
+    {% block title %}
     <h1>{{this.title}}</h1>
     {% endblock %}
   </div>
@@ -23,8 +23,8 @@
   <div class="row">
 
     {% block sidebar %}
-    <div class="col-md-3" role="navigation"> 
-      {% if this.toc %} 
+    <div class="col-md-3" role="navigation">
+      {% if this.toc %}
       <div class="sidebar" data-spy="affix" data-offset-top="80" data-offset-bottom="60">
         <div class="well">
           <a href="#"><strong>{{this.title}}</strong></a>
@@ -34,7 +34,7 @@
       {% endif %}
     </div>
     {% endblock %}
- 
+
     <div class="content">
       {% block content %}
       <div class="col-md-6" role="main">
@@ -44,7 +44,7 @@
     </div>
 
   </div>
-    
+
   {% if this.pager %}
   <ul class="pager">
     {% if this.prev %}
@@ -58,7 +58,7 @@
 
   {% include 'footer.html' %}
 
-</div> 
+</div>
 
 {% endblock %}
 


### PR DESCRIPTION
This is the companion PR to https://github.com/jandecaluwe/urubu/pull/18 updating the quickstart `_base.html` template so that it correctly handles a site `baseurl` option. The `baseurl` option needs to be used when pointing to the local CSS files and when setting the brand link in the navbar.
